### PR TITLE
Firestoreのキャッシュ機能を追加

### DIFF
--- a/lib/presentation/controller/quiz_controller.dart
+++ b/lib/presentation/controller/quiz_controller.dart
@@ -32,7 +32,7 @@ class QuizController extends StateNotifier<AsyncValue<List<Quiz>>> {
   Future<List<Quiz>> retrieveQuiz() async {
     try {
       final quizList = await ref.watch(quizRepositoryProvider)
-          .retrieveQuiz(category: category);
+          .retrieveQuizList(category: category);
       if (mounted) {
         state = AsyncValue.data(quizList);
       }

--- a/lib/presentation/screens/original_question_set_screen.dart
+++ b/lib/presentation/screens/original_question_set_screen.dart
@@ -100,6 +100,7 @@ class OriginalQuestionSetScreen extends HookConsumerWidget {
   Widget _buildOptionHeader(Size screenSize) {
     return SizedBox(
       width: screenSize.width * 0.9,
+      height: screenSize.height * 0.05,
       child: const Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [

--- a/lib/presentation/screens/original_question_set_screen.dart
+++ b/lib/presentation/screens/original_question_set_screen.dart
@@ -67,7 +67,7 @@ class OriginalQuestionSetScreen extends HookConsumerWidget {
           controller: textControllerProvider,
           error: questionValidator.form.text.errorMessage,
           onChanged: (text) => questionValidatorNotifier.setQuestionText(text)),
-      const SizedBox(height: 10),
+      SizedBox(height: screenSize.height * 0.05),
       _buildOptionHeader(screenSize),
       ..._buildOptions(
           context, ref, screenSize, optionValidator, optionValidatorNotifier),
@@ -165,7 +165,7 @@ class OriginalQuestionSetScreen extends HookConsumerWidget {
               ],
             ),
           ),
-          const SizedBox(height: 10),
+      SizedBox(height: screenSize.height * 0.05),
         ],
       );
     });


### PR DESCRIPTION
## 概要
キャッシュがある場合はFirestoreにデータを取りに行かずにキャッシュを使用するように変更

## 詳細
以下の repository でキャッシュの機能を追加
- category
- dictionary item
- original question
- question
- quiz history
- quiz