### PR TITLE
【Don't Merge】Go router builder の対応

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/lib/presentation/auth_routes.dart
+++ b/lib/presentation/auth_routes.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:quiz_app/presentation/screens/login_screen.dart';
+import 'package:quiz_app/presentation/screens/signup_screen.dart';
+
+const signupRoute = TypedGoRoute<SignupRoute>(path: '/signup');
+
+class SignupRoute extends GoRouteData {
+  const SignupRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+      key: state.pageKey,
+      child: const SignupScreen(),
+    );
+  }
+}
+
+const loginRoute = TypedGoRoute<LoginRoute>(path: '/login');
+
+class LoginRoute extends GoRouteData {
+  const LoginRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+      key: state.pageKey,
+      child: const LoginScreen(),
+    );
+  }
+}

--- a/lib/presentation/category_routes.dart
+++ b/lib/presentation/category_routes.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:quiz_app/domain/category/category.dart';
+import 'package:quiz_app/presentation/screens/category_detail_screen.dart';
+// import 'package:quiz_app/domain/category/category.dart';
+// import 'package:quiz_app/presentation/screens/category_detail_screen.dart';
+import 'package:quiz_app/presentation/screens/category_list_screen.dart';
+
+const categoryRoutes = TypedGoRoute<CategoryListRoute>(
+  path: '/category-list',
+  routes: [
+    TypedGoRoute<CategoryDetailRoute>(path: 'detail'),
+  ],
+);
+
+class CategoryBranchData extends StatefulShellBranchData {
+  const CategoryBranchData();
+}
+
+class CategoryListRoute extends GoRouteData {
+  const CategoryListRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+        key: state.pageKey, child: const CategoryListScreen());
+  }
+}
+
+class CategoryDetailRoute extends GoRouteData {
+  const CategoryDetailRoute({required this.category});
+
+  final Category category;
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+      key: state.pageKey,
+      child: CategoryDetailScreen(
+        category: category,
+      ),
+    );
+  }
+}

--- a/lib/presentation/original_question_routes.dart
+++ b/lib/presentation/original_question_routes.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:quiz_app/presentation/screens/original_question_list_screen.dart';
+import 'package:quiz_app/presentation/screens/original_question_set_screen.dart';
+
+const originalQuestionRoutes = TypedGoRoute<OriginalQuestionListRoute>(
+    path: '/original-question-list',
+    routes: [
+      TypedGoRoute<OriginalQuestionSetRoute>(path: 'original-question-set'),
+    ]);
+
+class OriginalQuestionListRoute extends GoRouteData {
+  const OriginalQuestionListRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+      key: state.pageKey,
+      child: OriginalQuestionListScreen(),
+    );
+  }
+}
+
+class OriginalQuestionSetRoute extends GoRouteData {
+  const OriginalQuestionSetRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+      key: state.pageKey,
+      child: const OriginalQuestionSetScreen(),
+    );
+  }
+}

--- a/lib/presentation/quiz_routes.dart
+++ b/lib/presentation/quiz_routes.dart
@@ -1,0 +1,82 @@
+// import 'package:flutter/foundation.dart';
+// import 'package:flutter/material.dart';
+// import 'package:go_router/go_router.dart';
+// import 'package:hooks_riverpod/hooks_riverpod.dart';
+// import 'package:quiz_app/domain/dto/quiz_result.dart';
+// import 'package:quiz_app/domain/question/question.dart';
+// import 'package:quiz_app/presentation/screens/quiz_list_screen.dart';
+// import 'package:quiz_app/presentation/screens/quiz_result_screen.dart';
+// import 'package:quiz_app/presentation/screens/quiz_screen.dart';
+
+// const quizRoutes = TypedGoRoute<QuizListRoute>(
+//   path: '/quiz-list',
+  // routes: [
+  //   TypedGoRoute<QuizRoute>(
+  //     path: 'quiz',
+  //     routes: [
+  //       TypedGoRoute<QuizResultRoute>(
+  //         path: 'quiz-result',
+  //       ),
+  //     ],
+  //   ),
+  // ],
+// );
+
+// class QuizListRoute extends GoRouteData {
+//   const QuizListRoute({required this.category});
+
+//   final Category category;
+
+//   @override
+//   Page<void> buildPage(BuildContext context, GoRouterState state) {
+//     return NoTransitionPage(
+//       key: state.pageKey,
+//       child: QuizListScreen(category: category),
+//     );
+//   }
+// }
+
+// class QuizRoute extends GoRouteData {
+//   const QuizRoute({required this.ref, required this.questionList});
+
+//   final WidgetRef ref;
+//   final List<Question> questionList;
+
+//   @override
+//   Page<void> buildPage(BuildContext context, GoRouterState state) {
+//     return NoTransitionPage(
+//       key: state.pageKey,
+//       child: QuizScreen(
+//         questionList: questionList,
+//         ref: ref,
+//       ),
+//     );
+//   }
+// }
+
+// class QuizResultRoute extends GoRouteData {
+//   const QuizResultRoute({
+//     required this.answerIsCorrectList,
+//     required this.questionList,
+//     required this.result,
+//     required this.takenQuestions,
+//   });
+
+//   final List<bool> answerIsCorrectList;
+//   final List<Question> questionList;
+//   final QuizResult result;
+//   final List<int> takenQuestions;
+
+//   @override
+//   Page<void> buildPage(BuildContext context, GoRouterState state) {
+//     return NoTransitionPage(
+//       key: state.pageKey,
+//       child: QuizResultScreen(
+//         answerIsCorrectList: answerIsCorrectList,
+//         questionList: questionList,
+//         result: result,
+//         takenQuestions: takenQuestions,
+//       ),
+//     );
+//   }
+// }

--- a/lib/presentation/review_routes.dart
+++ b/lib/presentation/review_routes.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:quiz_app/presentation/screens/quiz_history_screen.dart';
+import 'package:quiz_app/presentation/screens/review_screen.dart';
+import 'package:quiz_app/presentation/screens/weak_question_screen.dart';
+
+const reviewRoutes = TypedGoRoute<ReviewRoute>(
+  path: '/review',
+  routes: [
+    TypedGoRoute<WeakQuestionRoute>(path: 'weak-question'),
+    TypedGoRoute<QuizHistoryRoute>(path: 'quiz-history'),
+  ],
+);
+
+class ReviewRoute extends GoRouteData {
+  const ReviewRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(key: state.pageKey, child: const ReviewScreen());
+  }
+}
+
+class WeakQuestionRoute extends GoRouteData {
+  const WeakQuestionRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+      key: state.pageKey,
+      child: const WeakQuestionScreen(),
+    );
+  }
+}
+
+class QuizHistoryRoute extends GoRouteData {
+  const QuizHistoryRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+      key: state.pageKey,
+      child: const QuizHistoryScreen(),
+    );
+  }
+}

--- a/lib/presentation/routers.dart
+++ b/lib/presentation/routers.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:quiz_app/presentation/screens/category_list_screen.dart';
+import 'package:quiz_app/presentation/screens/dictionary_screen.dart';
+import 'package:quiz_app/presentation/screens/home_screen.dart';
+import 'package:quiz_app/presentation/screens/intro_slider_screen.dart';
+import 'package:quiz_app/presentation/screens/login_screen.dart';
+import 'package:quiz_app/presentation/screens/original_question_list_screen.dart';
+import 'package:quiz_app/presentation/screens/original_question_set_screen.dart';
+import 'package:quiz_app/presentation/screens/quiz_history_screen.dart';
+import 'package:quiz_app/presentation/screens/review_screen.dart';
+import 'package:quiz_app/presentation/screens/setting_screen.dart';
+import 'package:quiz_app/presentation/screens/signup_screen.dart';
+import 'package:quiz_app/presentation/screens/weak_question_screen.dart';
+
+part 'routers.g.dart';
+
+@TypedGoRoute<HomeRoute>(
+  path: '/',
+)
+class HomeRoute extends GoRouteData {
+  const HomeRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) => const HomeScreen();
+}
+
+@TypedGoRoute<RootRoute>(path: '/intro-slider')
+class RootRoute extends GoRouteData {
+  const RootRoute();
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+      key: state.pageKey,
+      // intro なのか home なのか 空のScaffold なのか
+      child: const IntroSliderScreen(),
+    );
+  }
+}
+
+// auth routes
+@TypedGoRoute<SignupRoute>(path: '/signup')
+class SignupRoute extends GoRouteData {
+  const SignupRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+      key: state.pageKey,
+      child: const SignupScreen(),
+    );
+  }
+}
+
+@TypedGoRoute<LoginRoute>(path: '/login')
+class LoginRoute extends GoRouteData {
+  const LoginRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+      key: state.pageKey,
+      child: const LoginScreen(),
+    );
+  }
+}
+
+// category routes
+@TypedGoRoute<CategoryListRoute>(
+  path: '/category-list',
+)
+class CategoryListRoute extends GoRouteData {
+  const CategoryListRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+        key: state.pageKey, child: const CategoryListScreen());
+  }
+}
+
+// original question routes
+@TypedGoRoute<OriginalQuestionListRoute>(
+    path: '/original-question-list',
+    routes: [
+      TypedGoRoute<OriginalQuestionSetRoute>(
+        path: 'original-question-set',
+      ),
+    ])
+class OriginalQuestionListRoute extends GoRouteData {
+  const OriginalQuestionListRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+      key: state.pageKey,
+      child: OriginalQuestionListScreen(),
+    );
+  }
+}
+
+class OriginalQuestionSetRoute extends GoRouteData {
+  const OriginalQuestionSetRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+      key: state.pageKey,
+      child: const OriginalQuestionSetScreen(),
+    );
+  }
+}
+
+// review routes
+@TypedGoRoute<ReviewRoute>(
+  path: '/review',
+  routes: [
+    TypedGoRoute<WeakQuestionRoute>(path: 'weak-question'),
+    TypedGoRoute<QuizHistoryRoute>(path: 'quiz-history'),
+  ],
+)
+class ReviewRoute extends GoRouteData {
+  const ReviewRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(key: state.pageKey, child: const ReviewScreen());
+  }
+}
+
+class WeakQuestionRoute extends GoRouteData {
+  const WeakQuestionRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+      key: state.pageKey,
+      child: const WeakQuestionScreen(),
+    );
+  }
+}
+
+class QuizHistoryRoute extends GoRouteData {
+  const QuizHistoryRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+      key: state.pageKey,
+      child: const QuizHistoryScreen(),
+    );
+  }
+}
+
+// setting routes
+@TypedGoRoute<SettingRoute>(path: '/setting', routes: [
+  TypedGoRoute<DictionaryRoute>(path: 'dictionary'),
+])
+class SettingRoute extends GoRouteData {
+  const SettingRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(key: state.pageKey, child: const SettingScreen());
+  }
+}
+
+class DictionaryRoute extends GoRouteData {
+  const DictionaryRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+      key: state.pageKey,
+      child: const DictionaryScreen(),
+    );
+  }
+}

--- a/lib/presentation/routers.g.dart
+++ b/lib/presentation/routers.g.dart
@@ -1,0 +1,290 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'routers.dart';
+
+// **************************************************************************
+// GoRouterGenerator
+// **************************************************************************
+
+List<RouteBase> get $appRoutes => [
+      $homeRoute,
+      $rootRoute,
+      $signupRoute,
+      $loginRoute,
+      $categoryListRoute,
+      $originalQuestionListRoute,
+      $reviewRoute,
+      $settingRoute,
+    ];
+
+RouteBase get $homeRoute => GoRouteData.$route(
+      path: '/',
+      factory: $HomeRouteExtension._fromState,
+    );
+
+extension $HomeRouteExtension on HomeRoute {
+  static HomeRoute _fromState(GoRouterState state) => const HomeRoute();
+
+  String get location => GoRouteData.$location(
+        '/',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $rootRoute => GoRouteData.$route(
+      path: '/intro-slider',
+      factory: $RootRouteExtension._fromState,
+    );
+
+extension $RootRouteExtension on RootRoute {
+  static RootRoute _fromState(GoRouterState state) => const RootRoute();
+
+  String get location => GoRouteData.$location(
+        '/intro-slider',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $signupRoute => GoRouteData.$route(
+      path: '/signup',
+      factory: $SignupRouteExtension._fromState,
+    );
+
+extension $SignupRouteExtension on SignupRoute {
+  static SignupRoute _fromState(GoRouterState state) => const SignupRoute();
+
+  String get location => GoRouteData.$location(
+        '/signup',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $loginRoute => GoRouteData.$route(
+      path: '/login',
+      factory: $LoginRouteExtension._fromState,
+    );
+
+extension $LoginRouteExtension on LoginRoute {
+  static LoginRoute _fromState(GoRouterState state) => const LoginRoute();
+
+  String get location => GoRouteData.$location(
+        '/login',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $categoryListRoute => GoRouteData.$route(
+      path: '/category-list',
+      factory: $CategoryListRouteExtension._fromState,
+    );
+
+extension $CategoryListRouteExtension on CategoryListRoute {
+  static CategoryListRoute _fromState(GoRouterState state) =>
+      const CategoryListRoute();
+
+  String get location => GoRouteData.$location(
+        '/category-list',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $originalQuestionListRoute => GoRouteData.$route(
+      path: '/original-question-list',
+      factory: $OriginalQuestionListRouteExtension._fromState,
+      routes: [
+        GoRouteData.$route(
+          path: 'original-question-set',
+          factory: $OriginalQuestionSetRouteExtension._fromState,
+        ),
+      ],
+    );
+
+extension $OriginalQuestionListRouteExtension on OriginalQuestionListRoute {
+  static OriginalQuestionListRoute _fromState(GoRouterState state) =>
+      const OriginalQuestionListRoute();
+
+  String get location => GoRouteData.$location(
+        '/original-question-list',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $OriginalQuestionSetRouteExtension on OriginalQuestionSetRoute {
+  static OriginalQuestionSetRoute _fromState(GoRouterState state) =>
+      const OriginalQuestionSetRoute();
+
+  String get location => GoRouteData.$location(
+        '/original-question-list/original-question-set',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $reviewRoute => GoRouteData.$route(
+      path: '/review',
+      factory: $ReviewRouteExtension._fromState,
+      routes: [
+        GoRouteData.$route(
+          path: 'weak-question',
+          factory: $WeakQuestionRouteExtension._fromState,
+        ),
+        GoRouteData.$route(
+          path: 'quiz-history',
+          factory: $QuizHistoryRouteExtension._fromState,
+        ),
+      ],
+    );
+
+extension $ReviewRouteExtension on ReviewRoute {
+  static ReviewRoute _fromState(GoRouterState state) => const ReviewRoute();
+
+  String get location => GoRouteData.$location(
+        '/review',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $WeakQuestionRouteExtension on WeakQuestionRoute {
+  static WeakQuestionRoute _fromState(GoRouterState state) =>
+      const WeakQuestionRoute();
+
+  String get location => GoRouteData.$location(
+        '/review/weak-question',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $QuizHistoryRouteExtension on QuizHistoryRoute {
+  static QuizHistoryRoute _fromState(GoRouterState state) =>
+      const QuizHistoryRoute();
+
+  String get location => GoRouteData.$location(
+        '/review/quiz-history',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $settingRoute => GoRouteData.$route(
+      path: '/setting',
+      factory: $SettingRouteExtension._fromState,
+      routes: [
+        GoRouteData.$route(
+          path: 'dictionary',
+          factory: $DictionaryRouteExtension._fromState,
+        ),
+      ],
+    );
+
+extension $SettingRouteExtension on SettingRoute {
+  static SettingRoute _fromState(GoRouterState state) => const SettingRoute();
+
+  String get location => GoRouteData.$location(
+        '/setting',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $DictionaryRouteExtension on DictionaryRoute {
+  static DictionaryRoute _fromState(GoRouterState state) =>
+      const DictionaryRoute();
+
+  String get location => GoRouteData.$location(
+        '/setting/dictionary',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}

--- a/lib/presentation/screens/category_detail_screen.dart
+++ b/lib/presentation/screens/category_detail_screen.dart
@@ -10,6 +10,8 @@ class CategoryDetailScreen extends HookConsumerWidget {
       : super(key: key);
 
   final Category category;
+  static String get routeName => 'category-detail';
+  static String get routeLocation => '/$routeName';
 
   String _calcProcessTime(int categoryCount) {
     final processTime = categoryCount * 10;

--- a/lib/presentation/screens/category_list_screen.dart
+++ b/lib/presentation/screens/category_list_screen.dart
@@ -8,6 +8,9 @@ import 'package:quiz_app/presentation/widgets/category_card.dart';
 class CategoryListScreen extends HookConsumerWidget {
   const CategoryListScreen({Key? key}) : super(key: key);
 
+  static String get routeName => 'category-list';
+  static String get routeLocation => '/$routeName';
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final categoryListState = ref.watch(categoryControllerProvider);
@@ -62,7 +65,8 @@ class CategoryListScreen extends HookConsumerWidget {
 
   Widget _buildLoadingState() {
     return Center(
-      child: Lottie.asset("assets/json_files/loading.json", width: 200, height: 200),
+      child: Lottie.asset("assets/json_files/loading.json",
+          width: 200, height: 200),
     );
   }
 }

--- a/lib/presentation/screens/category_set_screen.dart
+++ b/lib/presentation/screens/category_set_screen.dart
@@ -8,6 +8,9 @@ import 'package:quiz_app/presentation/widgets/custom_text_field.dart';
 class CategorySetScreen extends HookConsumerWidget {
   const CategorySetScreen({Key? key}) : super(key: key);
 
+  static String get routeName => 'category-set';
+  static String get routeLocation => '/$routeName';
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final idControllerProvider = ref.watch(categoryIdControllerProvider);

--- a/lib/presentation/screens/dictionary_screen.dart
+++ b/lib/presentation/screens/dictionary_screen.dart
@@ -8,6 +8,9 @@ import 'package:quiz_app/presentation/widgets/dictionary_card.dart';
 class DictionaryScreen extends HookConsumerWidget {
   const DictionaryScreen({Key? key}) : super(key: key);
 
+  static String get routeName => 'dictionary';
+  static String get routeLocation => '/$routeName';
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final dictionaryItemState = ref.watch(dictionaryItemControllerProvider);

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -14,11 +14,14 @@ final List homePageList = [
   const CategoryListScreen(),
   const ReviewScreen(),
   OriginalQuestionListScreen(),
-  SettingScreen(),
+  const SettingScreen(),
 ];
 
 class HomeScreen extends HookConsumerWidget {
   const HomeScreen({Key? key}) : super(key: key);
+
+  static String get routeName => 'home';
+  static String get routeLocation => '/';
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/presentation/screens/intro_slider_screen.dart
+++ b/lib/presentation/screens/intro_slider_screen.dart
@@ -1,12 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:intro_slider/intro_slider.dart';
 import 'package:lottie/lottie.dart';
+// import 'package:quiz_app/presentation/auth_routes.dart';
+import 'package:quiz_app/presentation/routers.dart';
+// import 'package:quiz_app/presentation/auth_routes.dart';
+// import 'package:quiz_app/presentation/screens/signup_screen.dart';
 
 class IntroSliderScreen extends StatelessWidget {
   const IntroSliderScreen({Key? key}) : super(key: key);
 
-  final TextStyle _titleStyle = const TextStyle(color: Colors.cyan, fontSize: 20);
-  final TextStyle _descriptionStyle = const TextStyle(color: Colors.cyan, fontSize: 18);
+  static String get routeName => 'intro-slider';
+  static String get routeLocation => '/$routeName';
+
+  final TextStyle _titleStyle =
+      const TextStyle(color: Colors.cyan, fontSize: 20);
+  final TextStyle _descriptionStyle =
+      const TextStyle(color: Colors.cyan, fontSize: 18);
   final Color _bgColor = Colors.white;
 
   List<ContentConfig> get slides => [
@@ -57,7 +66,13 @@ class IntroSliderScreen extends StatelessWidget {
   Widget _renderDoneBtn(BuildContext context) {
     return TextButton(
       onPressed: () {
-        Navigator.pushNamed(context, "/signup");
+        const SignupRoute().go(context);
+        // Navigator.push(
+        //   context,
+        //   MaterialPageRoute(
+        //     builder: (context) => const SignupScreen(),
+        //   ),
+        // );
       },
       child: const Text("終了"),
     );

--- a/lib/presentation/screens/login_screen.dart
+++ b/lib/presentation/screens/login_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:quiz_app/presentation/controller/login_text_controller.dart';
 import 'package:quiz_app/presentation/controller/validator/login_validator_provider.dart';
-import 'package:quiz_app/presentation/screens/signup_screen.dart';
+import 'package:quiz_app/presentation/routers.dart';
 import 'package:quiz_app/presentation/widgets/apple_signin_button.dart';
 import 'package:quiz_app/presentation/widgets/custom_text_field.dart';
 import 'package:quiz_app/presentation/widgets/google_signin_button.dart';
@@ -10,6 +10,9 @@ import 'package:quiz_app/presentation/widgets/login_button.dart';
 
 class LoginScreen extends HookConsumerWidget {
   const LoginScreen({Key? key}) : super(key: key);
+
+  static String get routeName => 'login';
+  static String get routeLocation => '/$routeName';
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -90,10 +93,11 @@ class LoginScreen extends HookConsumerWidget {
               padding: const EdgeInsets.all(6.0),
               child: TextButton(
                 onPressed: () {
-                  Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                          builder: (context) => const SignupScreen()));
+                  // Navigator.push(
+                  //     context,
+                  //     MaterialPageRoute(
+                  //         builder: (context) => const SignupScreen()));
+                  const SignupRoute().go(context);
                 },
                 child: const Text(
                   "新規登録はこちら",

--- a/lib/presentation/screens/original_question_list_screen.dart
+++ b/lib/presentation/screens/original_question_list_screen.dart
@@ -3,14 +3,15 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lottie/lottie.dart';
 import 'package:quiz_app/domain/question/question.dart';
 import 'package:quiz_app/presentation/controller/original_question_controller.dart';
+import 'package:quiz_app/presentation/routers.dart';
 import 'package:quiz_app/presentation/screens/quiz_screen.dart';
 import 'package:quiz_app/presentation/widgets/original_question_list_card.dart';
-
-import 'original_question_set_screen.dart';
 
 class OriginalQuestionListScreen extends HookConsumerWidget {
   OriginalQuestionListScreen({Key? key}) : super(key: key);
 
+  static String get routeName => 'original-question-list';
+  static String get routeLocation => '/$routeName';
   final List<String> dictionaryWordList = [];
   final List<String> dictionaryDescriptionList = [];
   final List<String> dictionaryUrlList = [];
@@ -35,10 +36,13 @@ class OriginalQuestionListScreen extends HookConsumerWidget {
       title: const Text("オリジナル問題"),
       actions: [
         IconButton(
-          onPressed: () => Navigator.push(
-              context,
-              MaterialPageRoute(
-                  builder: (context) => const OriginalQuestionSetScreen())),
+          // onPressed: () => Navigator.push(
+          //     context,
+          //     MaterialPageRoute(
+          //         builder: (context) => const OriginalQuestionSetScreen())),
+          onPressed: () {
+            const OriginalQuestionSetRoute().go(context);
+          },
           icon: Icon(Icons.add, color: Theme.of(context).colorScheme.primary),
         ),
       ],

--- a/lib/presentation/screens/original_question_set_screen.dart
+++ b/lib/presentation/screens/original_question_set_screen.dart
@@ -12,6 +12,9 @@ import 'package:quiz_app/presentation/widgets/original_question_set_button.dart'
 class OriginalQuestionSetScreen extends HookConsumerWidget {
   const OriginalQuestionSetScreen({Key? key}) : super(key: key);
 
+    static String get routeName => 'original-question-set';
+  static String get routeLocation => '/$routeName';
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final screenSize = MediaQuery.of(context).size;

--- a/lib/presentation/screens/question_set_screen.dart
+++ b/lib/presentation/screens/question_set_screen.dart
@@ -11,6 +11,8 @@ import 'package:quiz_app/presentation/widgets/question_set_button.dart';
 class QuestionSetScreen extends HookConsumerWidget {
   const QuestionSetScreen({required this.quiz, Key? key}) : super(key: key);
 
+  static String get routeName => 'question-set';
+  static String get routeLocation => '/$routeName';
   final Quiz quiz;
 
   @override

--- a/lib/presentation/screens/quiz_history_screen.dart
+++ b/lib/presentation/screens/quiz_history_screen.dart
@@ -6,7 +6,8 @@ import 'package:quiz_app/presentation/controller/quiz_history_controller.dart';
 import 'package:quiz_app/presentation/widgets/quiz_history_card.dart';
 
 class QuizHistoryScreen extends HookConsumerWidget {
-  static const routeName = '/quizHistory';
+  static String get routeName => 'quiz-history';
+  static String get routeLocation => '/$routeName';
 
   const QuizHistoryScreen({Key? key}) : super(key: key);
 

--- a/lib/presentation/screens/quiz_list_screen.dart
+++ b/lib/presentation/screens/quiz_list_screen.dart
@@ -9,6 +9,8 @@ import 'package:quiz_app/presentation/controller/quiz_controller.dart';
 import 'package:quiz_app/presentation/screens/quiz_screen.dart';
 
 class QuizListScreen extends HookConsumerWidget {
+  static String get routeName => 'quiz-list';
+  static String get routeLocation => '/$routeName';
   final Category? category;
   final List<Question>? questionList;
   final List<Quiz>? quizList;

--- a/lib/presentation/screens/quiz_result_screen.dart
+++ b/lib/presentation/screens/quiz_result_screen.dart
@@ -3,12 +3,13 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lottie/lottie.dart';
 import 'package:quiz_app/domain/dto/quiz_result.dart';
 import 'package:quiz_app/domain/question/question.dart';
+import 'package:quiz_app/presentation/routers.dart';
 import 'package:quiz_app/presentation/screens/quiz_screen.dart';
 import 'package:quiz_app/presentation/widgets/result_question_list_card.dart';
-import 'home_screen.dart';
 
 class QuizResultScreen extends HookConsumerWidget {
-  static const routeName = '/quizResult';
+  static String get routeName => 'quiz-result';
+  static String get routeLocation => '/$routeName';
   final QuizResult result;
   final List<int> takenQuestions;
   final List<bool> answerIsCorrectList;
@@ -160,8 +161,11 @@ class QuizResultScreen extends HookConsumerWidget {
     return Padding(
       padding: const EdgeInsets.all(10.0),
       child: ElevatedButton(
-        onPressed: () => Navigator.pushReplacement(context,
-            MaterialPageRoute(builder: (context) => const HomeScreen())),
+        // onPressed: () => Navigator.pushReplacement(context,
+        //     MaterialPageRoute(builder: (context) => const HomeScreen())),
+        onPressed: () {
+          const HomeRoute().pushReplacement(context);
+        },
         style: ElevatedButton.styleFrom(
           backgroundColor: Theme.of(context).colorScheme.primary,
         ),

--- a/lib/presentation/screens/quiz_screen.dart
+++ b/lib/presentation/screens/quiz_screen.dart
@@ -24,7 +24,8 @@ final currentQuestionTextProvider = StateProvider<String?>((ref) => "");
 
 // ignore: must_be_immutable
 class QuizScreen extends StatefulHookConsumerWidget {
-  static const routeName = '/quiz';
+  static String get routeName => 'quiz';
+  static String get routeLocation => '/$routeName';
   Category? category;
   Quiz? quiz;
   final List<Question> questionList;

--- a/lib/presentation/screens/quiz_set_screen.dart
+++ b/lib/presentation/screens/quiz_set_screen.dart
@@ -8,7 +8,8 @@ import 'package:quiz_app/presentation/widgets/quiz_set_button.dart';
 
 class QuizSetScreen extends HookConsumerWidget {
   const QuizSetScreen({required this.category, Key? key}) : super(key: key);
-
+  static String get routeName => 'quiz-set';
+  static String get routeLocation => '/$routeName';
   final Category category;
 
   @override

--- a/lib/presentation/screens/review_screen.dart
+++ b/lib/presentation/screens/review_screen.dart
@@ -11,6 +11,8 @@ final List<Widget> _reviewScreens = [
 
 class ReviewScreen extends HookConsumerWidget {
   const ReviewScreen({Key? key}) : super(key: key);
+  static String get routeName => 'review';
+  static String get routeLocation => '/$routeName';
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/presentation/screens/setting_screen.dart
+++ b/lib/presentation/screens/setting_screen.dart
@@ -3,13 +3,13 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:quiz_app/general/general_provider.dart';
 import 'package:quiz_app/presentation/controller/auth_controller.dart';
 import 'package:quiz_app/presentation/controller/deleted_user_controller.dart';
-import 'package:quiz_app/presentation/screens/dictionary_screen.dart';
-import 'package:quiz_app/presentation/screens/login_screen.dart';
+import 'package:quiz_app/presentation/routers.dart';
 import 'package:quiz_app/presentation/widgets/link_button.dart';
 
 class SettingScreen extends HookConsumerWidget {
-  SettingScreen({Key? key}) : super(key: key);
-
+  const SettingScreen({Key? key}) : super(key: key);
+  static String get routeName => 'setting';
+  static String get routeLocation => '/$routeName';
   static const _labelTextList = [
     "利用規約",
     "プライバシーポリシー",
@@ -67,8 +67,9 @@ class SettingScreen extends HookConsumerWidget {
       () => linkButton.launchUriWithString(context, _linkURLs[1]),
       () => linkButton.launchUriWithString(context, _linkURLs[2]),
       () => linkButton.launchUriWithString(context, _linkURLs[3]),
-      () => Navigator.push(context,
-          MaterialPageRoute(builder: (context) => const DictionaryScreen())),
+      // () => Navigator.push(context,
+      //     MaterialPageRoute(builder: (context) => const DictionaryScreen())),
+      () => const DictionaryRoute().go(context),
       () => _showLogoutDialog(context, ref),
       () => _showDeleteAccountDialog(context, ref),
     ];
@@ -81,11 +82,16 @@ class SettingScreen extends HookConsumerWidget {
         context,
         "ログアウトしますか？",
         () async {
-          await ref.watch(authControllerProvider.notifier).signOut();
-          if (ref.watch(firebaseAuthProvider).currentUser == null) {
-            Navigator.pushReplacement(context,
-                MaterialPageRoute(builder: (context) => const LoginScreen()));
-          }
+          await ref
+              .watch(authControllerProvider.notifier)
+              .signOut()
+              .then((value) {
+            if (ref.watch(firebaseAuthProvider).currentUser == null) {
+              // Navigator.pushReplacement(context,
+              //     MaterialPageRoute(builder: (context) => const LoginScreen()));
+              const LoginRoute().pushReplacement(context);
+            }
+          });
         },
       ),
     );
@@ -98,9 +104,14 @@ class SettingScreen extends HookConsumerWidget {
         context,
         "アカウントを削除しますか？",
         () async {
-          await ref.watch(deletedUserControllerProvider.notifier).deleteUser();
-          Navigator.pushReplacement(context,
-              MaterialPageRoute(builder: (context) => const LoginScreen()));
+          await ref
+              .watch(deletedUserControllerProvider.notifier)
+              .deleteUser()
+              .then((value) {
+            // Navigator.pushReplacement(context,
+            //     MaterialPageRoute(builder: (context) => const LoginScreen()));
+            const LoginRoute().pushReplacement(context);
+          });
         },
       ),
     );

--- a/lib/presentation/screens/signup_screen.dart
+++ b/lib/presentation/screens/signup_screen.dart
@@ -6,7 +6,7 @@ import 'package:quiz_app/domain/repository/auth_repository.dart';
 import 'package:quiz_app/presentation/controller/auth_controller.dart';
 import 'package:quiz_app/presentation/controller/signup_text_controller.dart';
 import 'package:quiz_app/presentation/controller/validator/signup_validator_provider.dart';
-import 'package:quiz_app/presentation/screens/home_screen.dart';
+import 'package:quiz_app/presentation/routers.dart';
 import 'package:quiz_app/presentation/widgets/apple_signin_button.dart';
 import 'package:quiz_app/presentation/widgets/custom_text_field.dart';
 import 'package:quiz_app/presentation/widgets/google_signin_button.dart';
@@ -15,6 +15,8 @@ import 'package:quiz_app/presentation/widgets/signup_button.dart';
 
 class SignupScreen extends HookConsumerWidget {
   const SignupScreen({Key? key}) : super(key: key);
+  static String get routeName => 'signup';
+  static String get routeLocation => '/$routeName';
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -132,9 +134,10 @@ class SignupScreen extends HookConsumerWidget {
           await ref.watch(authControllerProvider.notifier).signInAnnonymously();
           User? user = ref.watch(authRepositoryProvider).getCurrentUser();
           if (user != null) {
-            Navigator.of(context).pushReplacement(
-              MaterialPageRoute(builder: (context) => const HomeScreen()),
-            );
+            // Navigator.of(context).pushReplacement(
+            //   MaterialPageRoute(builder: (context) => const HomeScreen()),
+            // );
+            const HomeRoute().pushReplacement(context);
           }
         },
         child: Text(

--- a/lib/presentation/screens/weak_question_screen.dart
+++ b/lib/presentation/screens/weak_question_screen.dart
@@ -7,6 +7,9 @@ import 'package:quiz_app/presentation/widgets/weak_question_card.dart';
 class WeakQuestionScreen extends HookConsumerWidget {
   const WeakQuestionScreen({Key? key}) : super(key: key);
 
+  static String get routeName => 'weak-question';
+  static String get routeLocation => '/$routeName';
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final weakQuestionState = ref.watch(weakQuestionControllerProvider);

--- a/lib/presentation/setting_routes.dart
+++ b/lib/presentation/setting_routes.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:quiz_app/presentation/screens/dictionary_screen.dart';
+import 'package:quiz_app/presentation/screens/setting_screen.dart';
+
+const settingRoutes = TypedGoRoute<SettingRoute>(path: '/setting', routes: [
+  TypedGoRoute<DictionaryRoute>(path: 'dictionary'),
+]);
+
+class SettingRoute extends GoRouteData {
+  const SettingRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(key: state.pageKey, child: const SettingScreen());
+  }
+}
+
+class DictionaryRoute extends GoRouteData {
+  const DictionaryRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return NoTransitionPage(
+      key: state.pageKey,
+      child: const DictionaryScreen(),
+      );
+  }
+}

--- a/lib/presentation/widgets/apple_signin_button.dart
+++ b/lib/presentation/widgets/apple_signin_button.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:quiz_app/general/general_provider.dart';
 import 'package:quiz_app/presentation/controller/auth_controller.dart';
-import 'package:quiz_app/presentation/screens/home_screen.dart';
+import 'package:quiz_app/presentation/routers.dart';
 
 class AppleSignInButton extends HookConsumerWidget {
   const AppleSignInButton({Key? key}) : super(key: key);
@@ -12,19 +12,22 @@ class AppleSignInButton extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final screenWidth = MediaQuery.of(context).size.width;
     final isDark = isDarkMode(context);
-    final authControllerProviderNotifier = ref.watch(authControllerProvider.notifier);
-    
+    final authControllerProviderNotifier =
+        ref.watch(authControllerProvider.notifier);
+
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: SizedBox(
         height: 40,
         width: screenWidth * 0.9,
-        child: _buildOutlinedButton(context, authControllerProviderNotifier, isDark),
+        child: _buildOutlinedButton(
+            context, authControllerProviderNotifier, isDark),
       ),
     );
   }
 
-  OutlinedButton _buildOutlinedButton(BuildContext context, AuthController authControllerProviderNotifier, bool isDark) {
+  OutlinedButton _buildOutlinedButton(BuildContext context,
+      AuthController authControllerProviderNotifier, bool isDark) {
     final themeColor = isDark
         ? Theme.of(context).colorScheme.secondary
         : Theme.of(context).colorScheme.onBackground;
@@ -35,14 +38,17 @@ class AppleSignInButton extends HookConsumerWidget {
       onPressed: () async {
         User? user = await authControllerProviderNotifier.signInWithApple();
         if (user != null) {
-          Navigator.of(context).push(MaterialPageRoute(builder: (context) => const HomeScreen()));
+          // Navigator.of(context).push(MaterialPageRoute(builder: (context) => const HomeScreen()));
+          HomeRoute().go(context);
         }
       },
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Image.asset(
-            isDark ? "assets/images/apple_logo_dark.png" : "assets/images/apple_logo.png",
+            isDark
+                ? "assets/images/apple_logo_dark.png"
+                : "assets/images/apple_logo.png",
             width: 20,
             height: 20,
           ),

--- a/lib/presentation/widgets/google_signin_button.dart
+++ b/lib/presentation/widgets/google_signin_button.dart
@@ -4,7 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:quiz_app/domain/repository/auth_repository.dart';
 import 'package:quiz_app/general/general_provider.dart';
 import 'package:quiz_app/presentation/controller/auth_controller.dart';
-import 'package:quiz_app/presentation/screens/home_screen.dart';
+import 'package:quiz_app/presentation/routers.dart';
 
 class GoogleSignInButton extends HookConsumerWidget {
   const GoogleSignInButton({Key? key}) : super(key: key);
@@ -33,8 +33,10 @@ class GoogleSignInButton extends HookConsumerWidget {
               User? user = authRepository.getCurrentUser();
               if (user != null) {
                 if (!mounted) return;
-                Navigator.of(context).push(MaterialPageRoute(
-                    builder: (context) => const HomeScreen()));
+                //   Navigator.of(context).push(MaterialPageRoute(
+                //       builder: (context) => const HomeScreen()));
+                // }
+                const HomeRoute().go(context);
               }
             },
             child: Row(

--- a/lib/presentation/widgets/login_button.dart
+++ b/lib/presentation/widgets/login_button.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:quiz_app/presentation/controller/auth_controller.dart';
 import 'package:quiz_app/presentation/controller/validator/login_validator_provider.dart';
-import 'package:quiz_app/presentation/screens/home_screen.dart';
+import 'package:quiz_app/presentation/routers.dart';
 
 class LoginButton extends HookConsumerWidget {
   const LoginButton(this.email, this.password, {super.key});
@@ -58,8 +58,9 @@ class LoginButton extends HookConsumerWidget {
                     .signInWithEmailAndPassword(email, password);
                 if (user != null) {
                   if (!mounted) return;
-                  Navigator.of(context).pushReplacement(MaterialPageRoute(
-                      builder: (context) => const HomeScreen()));
+                  // Navigator.of(context).pushReplacement(MaterialPageRoute(
+                  //     builder: (context) => const HomeScreen()));
+                  const HomeRoute().pushReplacement(context);
                 } else {
                   showErrorDialog();
                 }

--- a/lib/presentation/widgets/signup_button.dart
+++ b/lib/presentation/widgets/signup_button.dart
@@ -4,7 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:quiz_app/domain/repository/auth_repository.dart';
 import 'package:quiz_app/presentation/controller/auth_controller.dart';
 import 'package:quiz_app/presentation/controller/validator/signup_validator_provider.dart';
-import 'package:quiz_app/presentation/screens/home_screen.dart';
+import 'package:quiz_app/presentation/routers.dart';
 
 class SignUpButton extends HookConsumerWidget {
   const SignUpButton(this.email, this.password, {super.key});
@@ -13,7 +13,7 @@ class SignUpButton extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final authControllerProviderNotifier =
-    ref.watch(authControllerProvider.notifier);
+        ref.watch(authControllerProvider.notifier);
     final authRepositoryProviderNotifier = ref.watch(authRepositoryProvider);
     return Padding(
       padding: const EdgeInsets.all(8.0),
@@ -27,13 +27,14 @@ class SignUpButton extends HookConsumerWidget {
                     : Theme.of(context).colorScheme.secondary),
             onPressed: ([bool mounted = true]) async {
               if (ref.watch(signupValidatorProvider).form.isValid) {
-                await authControllerProviderNotifier.createUserWithEmailAndPassword(
-                    email, password);
+                await authControllerProviderNotifier
+                    .createUserWithEmailAndPassword(email, password);
                 User? user = authRepositoryProviderNotifier.getCurrentUser();
                 if (user != null) {
-                  if(!mounted) return;
-                  Navigator.of(context).pushReplacement(MaterialPageRoute(
-                      builder: (context) => const HomeScreen()));
+                  if (!mounted) return;
+                  // Navigator.of(context).pushReplacement(MaterialPageRoute(
+                  //     builder: (context) => const HomeScreen()));
+                  const HomeRoute().pushReplacement(context);
                 }
               } else {
                 null;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -576,6 +576,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: a206cc4621a644531a2e05e7774616ab4d9d85eab1f3b0e255f3102937fccab1
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.0"
+  go_router_builder:
+    dependency: "direct dev"
+    description:
+      name: go_router_builder
+      sha256: b004ed761578fd1326054ff9c97daaf7b94f109b24cad843ca8bd349a810f947
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3"
   google_identity_services_web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   json_annotation: ^4.8.1
   fake_cloud_firestore: ^2.4.1+1
   firebase_auth_mocks: ^0.12.0
+  go_router: ^12.0.0
 
 dev_dependencies:
   flutter_test:
@@ -47,7 +48,7 @@ dev_dependencies:
   json_serializable: ^6.4.0
   flutter_native_splash: ^2.2.7
   flutter_launcher_icons: ^0.13.1
-  mockito: ^5.4.2
+  go_router_builder: ^2.3.3
 
 flutter_native_splash:
   image: "assets/images/sample_logo.png"

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:quiz_app/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(MyApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## 概要
アプリ全体のルーティングを Go router builder を使ったものに変更

## 現状
以下の解決すべき問題のためリプレイスを一時停止中
+ `Category`や`Question` といった自作のクラスを画面遷移先に渡す処理があり、その処理の実装には go router builder でコードを生成する段階で自作のクラスを引数として定義しなければならないが、現在(2023.10.28)自作のクラスの継承がサポートされていない

+ リダイレクトを用いてユーザーの認証が済んでいる場合と済んでいない場合に分けて画面遷移をする処理が不完全である

+ `HomeScreen`においてホームタブ、設定タブなどのタブの状態管理をしていたが、`StatefulShellRoute `の導入により、BottomNavigationBarを含むタブの画面遷移の管理も go router で可能になったため、その対応ができていない

+ 上記の問題に付属して、タブを含むホームページから一つ階層の深いページに遷移して、その後 pop したところ、ボトムナビゲーションバーが消えて、画面遷移ができない状態が発生している
例）以下の処理でボトムナビゲーションバーが消える
OriginalQuesitonListScreen → OriginalQuestionSetScreen → OriginalQuesitonListScreen

## TODO
- [ ] 自作クラスを渡す方法を考える or パッケージが自作クラスをサポートするアップデートを待つ
- [ ] redirect を他サンプルアプリで実装
- [ ] StatefulShellRoute を他サンプルアプリで実装